### PR TITLE
build(configuration): `module` property within package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.2.0",
   "description": "Circular Dependencies for most.js",
   "main": "lib/commonjs/index.js",
-  "module": "lib/es2015/index.js",
   "jsnext:main": "lib/es2015/index.js",
   "typings": "lib/es2015/index.d.ts",
   "scripts": {


### PR DESCRIPTION
I'm trying to create a bundled file so it can be served to the browser.

My `tsconfig.json` `module` and `target` fields configured to `commonjs` (module code generation)
and `es5`. I removed the `module` field locally within my `node_modules` folder and the end
footprint is `es5` as i configured through my own `tsconfig.json`.